### PR TITLE
feat(permissions): Additional resource permissions [ENG-45898]

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The following steps demonstrate how to connect GCP in Drata when using this scri
 5. Click the `Open terminal` button at the top of the editor to navigate back to your terminal, run the following commands.
    1. `chmod +x drata.sh` to give it execution permissions.
    2. `./drata.sh` to run the script.
-6. A prompt will show up and you must type `n` if the service account will target to a single project otherwise will access the entire organization.
+6. The prompt `Will the service account connect multiple projects? [y/n]` will appear. Respond with `n` if it is desired that the service account should only be added to a single project in your organization.
 7. After the process finishes, navigate back to your editor and download the `drata-key-file.json` file.
 8. In the Drata app, go to the GCP connection drawer and select Upload File to upload the `drata-key-file.json` file.
 9. Select the `Save & Test Connection` button.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The following steps demonstrate how to connect GCP in Drata when using this scri
 5. Click the `Open terminal` button at the top of the editor to navigate back to your terminal, run the following commands.
    1. `chmod +x drata.sh` to give it execution permissions.
    2. `./drata.sh` to run the script.
-6. A prompt will show up and you must type `n` or `N` if the service account will target to a single project otherwise will access the entire organization.
+6. A prompt will show up and you must type `n` if the service account will target to a single project otherwise will access the entire organization.
 7. After the process finishes, navigate back to your editor and download the `drata-key-file.json` file.
 8. In the Drata app, go to the GCP connection drawer and select Upload File to upload the `drata-key-file.json` file.
 9. Select the `Save & Test Connection` button.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ The following steps demonstrate how to connect GCP in Drata when using this scri
 2. Click the `Open editor` button at the top of the terminal to navigate to your editor.
 3. Create a file with `.sh` extension in the root directory i.e. `drata.sh`.
 4. Copy the content of the `gcp-drata-script.sh` from this project and paste it in the newly created file.
-5. Click the `Open terminal` button at the top of  the editor to navigate back to your terminal, run the following commands.
+5. Click the `Open terminal` button at the top of the editor to navigate back to your terminal, run the following commands.
    1. `chmod +x drata.sh` to give it execution permissions.
    2. `./drata.sh` to run the script.
-6. After the process finishes, navigate back to your editor and download the `drata-key-file.json` file.
-7. In the Drata app, go to the GCP connection drawer and select Upload File to upload the `drata-key-file.json` file.
-8. Select the `Save & Test Connection` button.
+6. A prompt will show up and you must type `n` or `N` if the service account will target to a single project otherwise will access the entire organization.
+7. After the process finishes, navigate back to your editor and download the `drata-key-file.json` file.
+8. In the Drata app, go to the GCP connection drawer and select Upload File to upload the `drata-key-file.json` file.
+9. Select the `Save & Test Connection` button.

--- a/gcp-drata-script.sh
+++ b/gcp-drata-script.sh
@@ -181,8 +181,9 @@ then
 else
   # if the user typed "No is multi project" then check if the viewer role is at the organization level and remove it
   removePolicy=$(
-    gcloud organizations get-iam-policy $organizationId --format='value(bindings.members)' --flatten=bindings --filter="bindings.role:roles/viewer AND bindings.members:serviceAccount:${serviceAccountEmail}"
+    gcloud organizations get-iam-policy $organizationId --format='value(bindings.members)' --flatten=bindings --filter="bindings.role:roles/viewer AND bindings.members ~ serviceAccount:${serviceAccountEmail}$"
   );
+  # if the service account has the viewer role then delete the policy
   if [ -n "$removePolicy" ]
   then
     gcloud organizations remove-iam-policy-binding $organizationId --member="serviceAccount:${serviceAccountEmail}" --role="roles/viewer" --no-user-output-enabled;

--- a/gcp-drata-script.sh
+++ b/gcp-drata-script.sh
@@ -136,7 +136,9 @@ printf "${prefix} '${organizationRole}' organization role has been created 🚀\
 gcloud iam roles update $organizationRole --organization=$organizationId --permissions="\
 resourcemanager.organizations.getIamPolicy,\
 storage.buckets.get,\
-storage.buckets.getIamPolicy" --no-user-output-enabled
+storage.buckets.getIamPolicy,\
+resourcemanager.folders.get,\
+resourcemanager.organizations.get" --no-user-output-enabled
 
 # ===========================
 # Service Account


### PR DESCRIPTION
## The Service Account needs additional permissions in order to read the folder and project names.

### It also needs another permission to be able to access to the entire organization projects, this is configurable.

- The user can choose whether the service account accesses the entire organization with a prompt by entering `y` or `n`. 
<img width="693" alt="image" src="https://github.com/drata/gcp-shell-drata-setup/assets/22245919/e84f78f1-21a7-4a31-95e9-355a58abcac5">

- The other permissions to read folders and projects are added in the policy. Check [here](https://github.com/drata/gcp-shell-drata-setup/pull/2/commits/2a8b04085a2bd454a6727878d92d6fe7ed86e044) 

[ENG-45898](https://drata.atlassian.net/browse/ENG-45898)

This step was added to the readme file
6. The prompt `Will the service account connect multiple projects? [y/n]` will appear. Respond with `n` if it is desired that the service account should only be added to a single project in your organization.


[ENG-45898]: https://drata.atlassian.net/browse/ENG-45898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ