### PR TITLE
feat(assets): add service and permission for Assets [ENG-45104]

### DIFF
--- a/gcp-drata-script.sh
+++ b/gcp-drata-script.sh
@@ -7,7 +7,7 @@ set -e
 prefix="[ Drata ]"
 
 # Resource names
-drata_role_name="DrataReadOnly"
+drata_role_name="ENG45104SHELL"
 serviceAccountId="${drata_role_name,,}"
 projectRole="${drata_role_name}ProjectRole"
 organizationRole="${drata_role_name}OrganizationalRole"
@@ -48,8 +48,14 @@ printf "\n${prefix} Will the service account connect multiple projects❓ [y/n] 
 read multipleProjects;
 
 printf "\n\n${prefix} Enabling services...🛜 \n"
-gcloud services enable compute.googleapis.com cloudresourcemanager.googleapis.com admin.googleapis.com \
-sqladmin.googleapis.com monitoring.googleapis.com --no-user-output-enabled 
+gcloud services enable \ 
+compute.googleapis.com \
+cloudresourcemanager.googleapis.com \
+admin.googleapis.com \
+sqladmin.googleapis.com \
+monitoring.googleapis.com \
+cloudasset.googleapis.com \
+--no-user-output-enabled 
 printf "${prefix} Necessary services enabled 🚀 \n\n"
 
 serviceAccountEmail="${serviceAccountId}@${projectId}.iam.gserviceaccount.com";
@@ -138,7 +144,8 @@ resourcemanager.organizations.getIamPolicy,\
 storage.buckets.get,\
 storage.buckets.getIamPolicy,\
 resourcemanager.folders.get,\
-resourcemanager.organizations.get" --no-user-output-enabled
+resourcemanager.organizations.get,\
+cloudasset.assets.searchAllResources" --no-user-output-enabled
 
 # ===========================
 # Service Account

--- a/gcp-drata-script.sh
+++ b/gcp-drata-script.sh
@@ -7,7 +7,7 @@ set -e
 prefix="[ Drata ]"
 
 # Resource names
-drata_role_name="ENG45104SHELL"
+drata_role_name="DrataReadOnly"
 serviceAccountId="${drata_role_name,,}"
 projectRole="${drata_role_name}ProjectRole"
 organizationRole="${drata_role_name}OrganizationalRole"


### PR DESCRIPTION
The following changes were added in order for GCP to get virtual assets working:

* Add `cloudasset.assets.searchAllResources` to the organizational role.
* Enable `cloudasset.googleapis.com` service.

[Terraform PR reference](https://github.com/drata/gcp-terraform-drata-setup/pull/4)

[ENG-45104](https://drata.atlassian.net/browse/ENG-45104)

[ENG-45104]: https://drata.atlassian.net/browse/ENG-45104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ